### PR TITLE
Fix Guzzle version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.5|^7.5",
+        "guzzlehttp/guzzle": "^6.5|^7.0",
         "webapix/dot-net-json-date-formatter": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hey, thanks for the package!

This is a bugfix PR, as Guzzle 7.5 does not exist, the newest version is 7.2. 

Laravel 8 itself requires Guzzle 7, but currently it's impossible to install this package (or `laravel-mygls` for that matter),  on Laravel 8 due to the wrong version constraint.