### PR TITLE
Allow CodAmount to be nullable

### DIFF
--- a/src/Models/Parcel.php
+++ b/src/Models/Parcel.php
@@ -27,7 +27,7 @@ class Parcel
     protected $count = 1;
 
     /**
-     * @var float
+     * @var float|null
      */
     protected $codAmount = 0;
 
@@ -97,12 +97,12 @@ class Parcel
         return $this;
     }
 
-    public function getCodAmount(): float
+    public function getCodAmount(): ?float
     {
         return $this->codAmount;
     }
 
-    public function setCodAmount(float $codAmount): self
+    public function setCodAmount(?float $codAmount): self
     {
         $this->codAmount = $codAmount;
 

--- a/tests/Unit/Models/ParcelTest.php
+++ b/tests/Unit/Models/ParcelTest.php
@@ -60,4 +60,13 @@ class ParcelTest extends TestCase
                 'StringValue' => 15496,
             ], ], $parcel->toArray()['ServiceList'][0]);
     }
+
+    /** @test */
+    public function cod_amount_can_be_nullable()
+    {
+        $parcel = (new Parcel)
+            ->setCodAmount(null);
+
+        $this->assertNull($parcel->getCodAmount());
+    }
 }


### PR DESCRIPTION
Hey

This PR makes it possible to set the CodAmount of parcels explicitely to `null`.

It is unfortunately not documented in the Gls API docs, but the API responds with weird .NET exceptions when sending parcels to Germany. After contacting GLS support, they told us that in order for it to work, CodAmount has to be explicitely set to `null`. 
After forking the package and testing it, this seems to be indeed the case.

The change is backwards compatible, so it does not require changing the major version.
