### PR TITLE
Fix/house number info mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `mygls-sdk` will be documented in this file
 
-# 3.0.1 - Unreleased
+# 3.0.1 - 2026-03-02
 
 - fix HouseNumberInfo incorrectly mapped to ContactName in Parcel::createAddress()
 - fix duplicate Count key in Parcel::toArray()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `mygls-sdk` will be documented in this file
 
+# 3.0.1 - Unreleased
+
+- fix HouseNumberInfo incorrectly mapped to ContactName in Parcel::createAddress()
+- fix duplicate Count key in Parcel::toArray()
+
 # 3.0.0 - 2025-02-21
 
 - add WebshopEngine field

--- a/src/Models/Parcel.php
+++ b/src/Models/Parcel.php
@@ -313,7 +313,7 @@ class Parcel
         }
 
         if (isset($addressData['HouseNumberInfo'])) {
-            $address->setContactName($addressData['HouseNumberInfo']);
+            $address->setHouseNumberInfo($addressData['HouseNumberInfo']);
         }
 
         return $address;

--- a/tests/Unit/Models/AddressTest.php
+++ b/tests/Unit/Models/AddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Webapix\GLS\Tests\Unit\Unit\Models;
+namespace Webapix\GLS\Tests\Unit\Models;
 
 use Webapix\GLS\Models\Address;
 use Webapix\GLS\Tests\TestCase;

--- a/tests/Unit/Models/ParcelTest.php
+++ b/tests/Unit/Models/ParcelTest.php
@@ -94,4 +94,77 @@ class ParcelTest extends TestCase
         $this->assertNull($parcel->getDeliveryInfo()->contactName());
         $this->assertNull($parcel->getDeliveryInfo()->contactEmail());
     }
+
+    /** @test */
+    public function it_preserves_house_number_info_and_does_not_override_contact_name()
+    {
+        $data = ParcelFactory::new()->create([
+            'DeliveryAddress' => [
+                'City' => 'Sülysáp',
+                'ContactEmail' => 'test@example.com',
+                'ContactName' => 'Test Test',
+                'ContactPhone' => '+3630123456789',
+                'CountryIsoCode' => 'HU',
+                'HouseNumber' => '1',
+                'HouseNumberInfo' => '2. épület 3. emelet',
+                'Name' => 'Delivery Address Name',
+                'Street' => 'Delivery Address Street',
+                'ZipCode' => 'Delivery Address ZipCode',
+            ],
+        ]);
+
+        $parcel = Parcel::fromArray($data);
+
+        $this->assertInstanceOf(Address::class, $parcel->getDeliveryInfo());
+        $this->assertEquals('2. épület 3. emelet', $parcel->getDeliveryInfo()->houseNumberInfo());
+        $this->assertEquals('Test Test', $parcel->getDeliveryInfo()->contactName());
+    }
+
+    /** @test */
+    public function it_sets_house_number_info_when_contact_name_is_missing()
+    {
+        $data = ParcelFactory::new()->create([
+            'DeliveryAddress' => [
+                'City' => 'Sülysáp',
+                'ContactPhone' => '+3630123456789',
+                'CountryIsoCode' => 'HU',
+                'HouseNumber' => '1',
+                'HouseNumberInfo' => 'B épület',
+                'Name' => 'Delivery Address Name',
+                'Street' => 'Delivery Address Street',
+                'ZipCode' => 'Delivery Address ZipCode',
+            ],
+        ]);
+
+        $parcel = Parcel::fromArray($data);
+
+        $this->assertInstanceOf(Address::class, $parcel->getDeliveryInfo());
+        $this->assertEquals('B épület', $parcel->getDeliveryInfo()->houseNumberInfo());
+        $this->assertNull($parcel->getDeliveryInfo()->contactName());
+    }
+
+    /** @test */
+    public function it_preserves_house_number_info_on_pickup_address()
+    {
+        $data = ParcelFactory::new()->create([
+            'PickupAddress' => [
+                'City' => 'Budapest',
+                'ContactEmail' => 'test@example.com',
+                'ContactName' => 'Pickup Contact',
+                'ContactPhone' => '+3620123456789',
+                'CountryIsoCode' => 'HU',
+                'HouseNumber' => '6',
+                'HouseNumberInfo' => 'A lépcsőház',
+                'Name' => 'Test name',
+                'Street' => 'street',
+                'ZipCode' => '12345',
+            ],
+        ]);
+
+        $parcel = Parcel::fromArray($data);
+
+        $this->assertInstanceOf(Address::class, $parcel->getPickupAddress());
+        $this->assertEquals('A lépcsőház', $parcel->getPickupAddress()->houseNumberInfo());
+        $this->assertEquals('Pickup Contact', $parcel->getPickupAddress()->contactName());
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed address mapping so house number info is stored in the correct address field and no longer overrides contact names.
  * Removed a duplicate parcel data key that could cause inconsistent output.

* **Tests**
  * Added/updated unit tests to verify house number info and contact name handling for delivery and pickup addresses.

* **Chores**
  * Updated changelog with a 3.0.1 entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->